### PR TITLE
[IMPROVEMENT] Add List Equality checks to optimize state management

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -28,3 +28,12 @@
 - We will be using Bloc for this Product Requirement.
 - Bloc State management emits only the changes that occur in the list. This will help in dispatching selective updates if the state becomes complex in the future.
 - The BLoC pattern reduces tight coupling between widgets. The `ListItemWidget` doesn't need to know about the parent `ListWidget`, it interacts with the state through the `ItemCubit`. Thus Separation of Concerns is achieved.
+
+# Code Changes for Optimizations 
+
+1. Convert `ListItemWidget` from Stateful to Stateless Widget. This removes unnecessary rebuilds of the Item widget.
+2. Added the `Equatable` package to enable list equality for the `Item` class.
+3. Added conditional  logic to BlocBuilder's `buildWhen` callback. The BlocBuilder widget will only rebuild if the condition in `buildWhen` callback.
+4. We have enforced, that Builder should only build if
+  - Previous list is not the same as Current list.
+  - Length of the Previous list does not match Length of the Current list.

--- a/lib/bloc_fix.dart
+++ b/lib/bloc_fix.dart
@@ -1,20 +1,31 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class Item {
-  int index;
-  int count = 0;
+class Item extends Equatable {
+  final int index;
+  final int count;
 
-  Item(this.index);
+  const Item({required this.index, this.count = 0});
+
+  @override
+  List<Object> get props => [index, count];
+
+  Item incrementCount() {
+    return Item(
+      index: index,
+      count: count + 1,
+    );
+  }
 }
 
 // Create a Cubit for managing the state
 class ItemCubit extends Cubit<List<Item>> {
-  ItemCubit() : super(List.generate(100, (index) => Item(index)));
+  ItemCubit() : super(List.generate(100, (index) => Item(index: index)));
 
   void incrementItem(Item item) {
     final updatedList = List.of(state)
-      ..[item.index].count = state[item.index].count + 1;
+      ..[item.index] = state[item.index].incrementCount();
     // Emit new state with updated items
     emit(updatedList);
   }
@@ -29,6 +40,10 @@ class ListWidget extends StatelessWidget {
       child: BlocProvider(
         create: (context) => ItemCubit(),
         child: BlocBuilder<ItemCubit, List<Item>>(
+          buildWhen: (previous, current) {
+            // Only rebuild if contents are not same
+            return previous != current || previous.length != current.length;
+          },
           builder: (context, state) {
             return ListView.builder(
               itemCount: state.length,
@@ -43,36 +58,32 @@ class ListWidget extends StatelessWidget {
   }
 }
 
-class ListItemWidget extends StatefulWidget {
+class ListItemWidget extends StatelessWidget {
   final Item item;
 
-  const ListItemWidget({required this.item, Key? key}) : super(key: key);
+  const ListItemWidget({
+    required this.item,
+    Key? key,
+  }) : super(key: key);
 
-  @override
-  State<ListItemWidget> createState() => _ListItemWidgetState();
-}
-
-class _ListItemWidgetState extends State<ListItemWidget> {
   @override
   Widget build(BuildContext context) {
     return BlocProvider.value(
       value: BlocProvider.of<ItemCubit>(context),
-      child: Builder(builder: (context) {
-        return Container(
-          padding: const EdgeInsets.all(4),
-          child: Row(
-            children: [
-              Text(widget.item.count.toString()),
-              MaterialButton(
-                onPressed: () {
-                  context.read<ItemCubit>().incrementItem(widget.item);
-                },
-                child: const Text("+"),
-              )
-            ],
-          ),
-        );
-      }),
+      child: Container(
+        padding: const EdgeInsets.all(4),
+        child: Row(
+          children: [
+            Text(item.count.toString()),
+            MaterialButton(
+              onPressed: () {
+                context.read<ItemCubit>().incrementItem(item);
+              },
+              child: const Text("+"),
+            )
+          ],
+        ),
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  equatable: ^2.0.5
   flutter_bloc: ^8.1.3
   cupertino_icons: ^1.0.2
 


### PR DESCRIPTION
## Goal
Improve existing implementation to optimize state management.

## Changes Done

1. Convert `ListItemWidget` from Stateful to Stateless Widget. This removes unnecessary rebuilds of the Item widget.
2. Added the `Equatable` package to enable list equality for the `Item` class.
3. Added conditional  logic to BlocBuilder's `buildWhen` callback. The BlocBuilder widget will only rebuild if the condition in `buildWhen` callback.
4. We have enforced, that Builder should only build if 
    - Previous list is not the same as Current list.
    - Length of the Previous list does not match Length of the Current list.